### PR TITLE
install eza instead of exa (which is unmaintained)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Crosup is a CLI tool to help you quickly setup your development environment on a
 - [x] Compatible with ChromeOS, Debian-based Linux, OpenSUSE, Fedora, RedHat, CentOS, Alpine and more!
 - [x] Detects your OS and installs the appropriate tools
 - [x] HCL/TOML configuration file
-- [x] Installs developer tools like docker, nix, devbox, homebrew, flox, fish, vscode, ble.sh, atuin, tig, fzf, httpie, kubectl, minikube, tilt, zellij, ripgrep, fd, exa, bat, glow, devenv and more!
+- [x] Installs developer tools like docker, nix, devbox, homebrew, flox, fish, vscode, ble.sh, atuin, tig, fzf, httpie, kubectl, minikube, tilt, zellij, ripgrep, fd, eza, bat, glow, devenv and more!
   
 ## 🚚 Installation
 
@@ -126,7 +126,7 @@ version_check = "kubectl"
 
 [brew.install.pkg.direnv]
 
-[brew.install.pkg.exa]
+[brew.install.pkg.eza]
 
 [brew.install.pkg.fd]
 

--- a/crates/types/src/brew.rs
+++ b/crates/types/src/brew.rs
@@ -94,7 +94,7 @@ pub fn default_brew_install() -> IndexMap<String, BrewConfiguration> {
     );
 
     pkg.insert(
-        "exa".into(),
+        "eza".into(),
         super::brew::Package {
             ..Default::default()
         },


### PR DESCRIPTION
fixes #79 